### PR TITLE
fix(declaration): fix multiple declaration of `unauthorized` property

### DIFF
--- a/koa.d.ts
+++ b/koa.d.ts
@@ -54,7 +54,6 @@ declare module 'koa' {
     | 'processing'
     | 'noContent'
     | 'resetContent'
-    | 'unauthorized'
     | 'proxyAuthenticationRequired'
 
   interface ExtendableContext


### PR DESCRIPTION
Fix error TS2320 caused by ambiguity when extending multiple types with the same named but not identical property