### PR TITLE
Fix can only be default-imported using the 'esModuleInterop' flag

### DIFF
--- a/koa.d.ts
+++ b/koa.d.ts
@@ -1,4 +1,5 @@
-import Koa, { ExtendableContext } from 'koa'
+import * as Koa from 'koa'
+import { ExtendableContext } from 'koa'
 
 declare module 'koa' {
   type KoaReponseTypeWithBody =


### PR DESCRIPTION

Hi

I have an error with your module:
```
node_modules/koa-response2/koa.d.ts(1,8): error TS1259: Module '"/Users/x/Devel/x/server/node_modules/@types/koa/index"' can only be default-imported using the 'esModuleInterop' flag
```

I propose a change to fix that.

I tested it by installing package locally, but I have limited TS experience.

Kind regards